### PR TITLE
fix: uri query param

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,15 +2,16 @@ import { Logo } from './logo'
 
 function registerProtocol () {
   console.log('registerProtocol')
+  
   navigator.registerProtocolHandler(
     'ipfs',
-    `${window.location}?url=%s`,
+    `${window.location.origin}/ipfs/?uri=%s`,
     'IPFS'
   );
 }
 
 function unregisterProtocol () {
-  navigator.unregisterProtocolHandler('ipfs', `${window.location}?url=%s`)
+  navigator.unregisterProtocolHandler('ipfs', `${window.location.origin}/ipfs/?uri=%s`)
 }
 
 export function App(props) {


### PR DESCRIPTION
@olizilla this change makes the API call use the correct path (which will work on every gateway):

1. it is `uri` not `url` :-)
2. `?uri=`  is scoped to only work under `/ipfs/` and `/ipns/` of some origin: 
   It _seems_ to be supported on dweb.link/ but it is not a canonicalpath for this
   (works only by a coincidence: `dweb.link` has dnslink , so behind the scenes 
   it is resolved under `/ipns/` namespace as  `/ipns/dweb.link/?uri=`)

